### PR TITLE
Fix code scanning alert no. 1: Log entries created from user input

### DIFF
--- a/SimpleCDN/CDNLoader.cs
+++ b/SimpleCDN/CDNLoader.cs
@@ -204,10 +204,10 @@ namespace SimpleCDN
 				when (ex is UnauthorizedAccessException or SecurityException)
 			{
 				// if we can't access the directory, we can't generate an index
-				_logger.LogError(ex, "Access denied to a publicly available folder ({path})", absolutePath);
+				_logger.LogError(ex, "Access denied to a publicly available folder ({path})", absolutePath.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", ""));
 			} catch (Exception ex)
 			{
-				_logger.LogError(ex, "Error while trying to load index file for {path}", absolutePath);
+				_logger.LogError(ex, "Error while trying to load index file for {path}", absolutePath.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", ""));
 			}
 			return MimeTypeHelpers.Empty;
 		}


### PR DESCRIPTION
Fixes [https://github.com/JonathanBout/SimpleCDN/security/code-scanning/1](https://github.com/JonathanBout/SimpleCDN/security/code-scanning/1)

To fix the problem, we need to sanitize the `absolutePath` variable before logging it. Since the log entries are plain text, we should remove any newline characters from the `absolutePath` to prevent log forging attacks. This can be done using the `String.Replace` method to replace newline characters with an empty string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
