### PR TITLE
Multi-Arch build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,17 +24,26 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        platform:
+          - arch: linux/arm64
+            dotnet_rid: linux-arm64
+            runner: buildjet-2vcpu-ubuntu-2204-arm
+          - arch: linux/amd64
+            dotnet_rid: linux-amd64
+            runner: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
       cancel-in-progress: true
-    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    runs-on: ${{ matrix.platform.runner }}
     permissions:
       contents: read
       packages: write
       # This is used to complete the identity challenge
       # with sigstore/fulcio when running outside of PRs.
       id-token: write
-
+    
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -77,6 +86,7 @@ jobs:
         id: build-and-push
         env:
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
+          DOTNET_PLATFORM: ${{ matrix.platform.dotnet_rid }}
         uses: docker/build-push-action@v6.10.0
         with:
           context: .
@@ -84,9 +94,9 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/arm64
+          platforms: ${{ matrix.platform.arch }}
           build-args: |
-            DOTNET_BUILD_PLATFORM=linux-arm64
+            DOTNET_BUILD_PLATFORM=$DOTNET_PLATFORM
             # set version number to the version in the tag name if this is a release
             # VERSION_NUMBER=$BRANCH_NAME
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,13 +26,18 @@ jobs:
   build:
     strategy:
       matrix:
-        platform:
-          - arch: linux/arm64
-            dotnet_rid: linux-arm64
-            runner: buildjet-2vcpu-ubuntu-2204-arm
-          - arch: linux/amd64
-            dotnet_rid: linux-amd64
-            runner: ubuntu-latest
+        platform: [
+          {
+            arch: "linux/arm64",
+            dotnet_rid: "linux-arm64",
+            runner: "buildjet-2vcpu-ubuntu-2204-arm"
+          },
+          {
+            arch: "linux/amd64",
+            dotnet_rid: "linux-amd64",
+            runner: "ubuntu-latest"
+          }
+        ]
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}-${{ matrix.arch }}
       cancel-in-progress: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,22 +26,17 @@ jobs:
   build:
     strategy:
       matrix:
-        platform: [
-          {
-            arch: "linux/arm64",
-            dotnet_rid: "linux-arm64",
-            runner: "buildjet-2vcpu-ubuntu-2204-arm"
-          },
-          {
-            arch: "linux/amd64",
-            dotnet_rid: "linux-amd64",
-            runner: "ubuntu-latest"
-          }
-        ]
+       include:
+        - arch: "linux/arm64"
+          dotnet_rid: "linux-arm64"
+          runner: "buildjet-2vcpu-ubuntu-2204-arm"
+        - arch: "linux/amd64"
+          dotnet_rid: "linux-amd64"
+          runner: "ubuntu-latest"
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}-${{ matrix.arch }}
       cancel-in-progress: true
-    runs-on: ${{ matrix.platform.runner }}
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -96,7 +91,7 @@ jobs:
         id: build-and-push
         env:
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
-          DOTNET_PLATFORM: ${{ matrix.platform.dotnet_rid }}
+          DOTNET_PLATFORM: ${{ matrix.dotnet_rid }}
         uses: docker/build-push-action@v6.10.0
         with:
           context: .
@@ -104,7 +99,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ matrix.platform.arch }}
+          platforms: ${{ matrix.arch }}
           build-args: |
             DOTNET_BUILD_PLATFORM=$DOTNET_PLATFORM
             # set version number to the version in the tag name if this is a release

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,7 +34,7 @@ jobs:
             dotnet_rid: linux-amd64
             runner: ubuntu-latest
     concurrency:
-      group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}-${{ matrix.arch }}
       cancel-in-progress: true
     runs-on: ${{ matrix.platform.runner }}
     permissions:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -50,6 +50,7 @@ jobs:
       id-token: write
     
     steps:
+      - name: Building for ${{ matrix.arch }} on ${{ matrix.runner }}
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -89,9 +89,6 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        env:
-          BRANCH_NAME: ${{ env.BRANCH_NAME }}
-          DOTNET_PLATFORM: ${{ matrix.dotnet_rid }}
         uses: docker/build-push-action@v6.10.0
         with:
           context: .
@@ -101,9 +98,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.arch }}
           build-args: |
-            DOTNET_BUILD_PLATFORM=$DOTNET_PLATFORM
-            # set version number to the version in the tag name if this is a release
-            # VERSION_NUMBER=$BRANCH_NAME
+            DOTNET_BUILD_PLATFORM=${{ matrix.dotnet_rid }}
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,6 +51,10 @@ jobs:
     
     steps:
       - name: Building for ${{ matrix.arch }} on ${{ matrix.runner }}
+        run: echo "Building for $ARCH on $RUNNER"
+        env:
+          ARCH: ${{ matrix.arch }}
+          RUNNER: ${{ matrix.runner }}
       - name: Checkout repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
This pull request includes changes to the `docker-publish.yml` workflow file to enhance the build process by adding support for multiple platforms. The most important changes include the introduction of a matrix strategy for different platforms and the use of matrix variables for platform-specific settings.

Enhancements to build process:

* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R27-R39): Added a matrix strategy to support both `linux/arm64` and `linux/amd64` platforms, including specific `dotnet_rid` and `runner` settings for each platform.
* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R27-R39): Updated the `runs-on` field to use the matrix runner value, allowing the job to run on the appropriate platform-specific runner.
* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R89-R99): Added `DOTNET_PLATFORM` environment variable to use the matrix `dotnet_rid` value, ensuring the correct .NET runtime identifier is used during the build process.
* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R89-R99): Updated the `platforms` field in the `build-and-push` step to use the matrix platform architecture, enabling the build for the specified platform.
* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R89-R99): Modified the `build-args` to dynamically set `DOTNET_BUILD_PLATFORM` using the `DOTNET_PLATFORM` environment variable.