### PR TITLE
Split unit- and integration test jobs

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,10 +14,8 @@ on:
       - '**.md'
 
 jobs:
-  build:
-
+  unit-test:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
@@ -25,8 +23,23 @@ jobs:
       with:
         dotnet-version: 9.0.x
     - name: Restore dependencies
-      run: dotnet restore SimpleCDN.sln
+      run: dotnet restore SimpleCDN.Tests/SimpleCDN.Tests.csproj
     - name: Build
-      run: dotnet build SimpleCDN.sln --no-restore
+      run: dotnet build SimpleCDN.Tests/SimpleCDN.Tests.csproj --no-restore
     - name: Test
-      run: dotnet test SimpleCDN.sln --no-build --verbosity normal
+      run: dotnet test SimpleCDN.Tests/SimpleCDN.Tests.csproj --no-build --verbosity normal
+
+  integration-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+    - name: Restore dependencies
+      run: dotnet restore SimpleCDN.Tests.Integration/SimpleCDN.Integration.csproj
+    - name: Build
+      run: dotnet build SimpleCDN.Tests.Integration/SimpleCDN.Integration.csproj --no-restore
+    - name: Test
+      run: dotnet test SimpleCDN.Tests.Integration/SimpleCDN.Integration.csproj --no-build --verbosity normal

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -38,8 +38,8 @@ jobs:
       with:
         dotnet-version: 9.0.x
     - name: Restore dependencies
-      run: dotnet restore SimpleCDN.Tests.Integration/SimpleCDN.Integration.csproj
+      run: dotnet restore SimpleCDN.Tests.Integration/SimpleCDN.Tests.Integration.csproj
     - name: Build
-      run: dotnet build SimpleCDN.Tests.Integration/SimpleCDN.Integration.csproj --no-restore
+      run: dotnet build SimpleCDN.Tests.Integration/SimpleCDN.Tests.Integration.csproj --no-restore
     - name: Test
-      run: dotnet test SimpleCDN.Tests.Integration/SimpleCDN.Integration.csproj --no-build --verbosity normal
+      run: dotnet test SimpleCDN.Tests.Integration/SimpleCDN.Tests.Integration.csproj --no-build --verbosity normal

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,7 +1,7 @@
 # This workflow will build a .NET project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
-name: NUnit Unit Tests
+name: Tests
 
 on:
   push:
@@ -16,6 +16,7 @@ on:
 jobs:
   unit-test:
     runs-on: ubuntu-latest
+    name: Unit Tests
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
@@ -31,6 +32,7 @@ jobs:
 
   integration-test:
     runs-on: ubuntu-latest
+    name: Integration Tests
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow configuration in the `.github/workflows/dotnet.yml` file to improve the CI/CD pipeline by separating unit tests and integration tests into distinct jobs.

Changes to GitHub Actions workflow:

* Renamed the `build` job to `unit-test` and added steps to checkout the repository, set up .NET, restore dependencies, build, and run unit tests on `SimpleCDN.Tests/SimpleCDN.Tests.csproj`.
* Added a new `integration-test` job with steps to checkout the repository, set up .NET, restore dependencies, build, and run integration tests on `SimpleCDN.Tests.Integration/SimpleCDN.Integration.csproj`.