### PR TITLE
Benchmarks and more unit tests, plus resulting bug fixes

### DIFF
--- a/SimpleCDN.Benchmarks/Benchmarks.cs
+++ b/SimpleCDN.Benchmarks/Benchmarks.cs
@@ -1,20 +1,42 @@
 ﻿using BenchmarkDotNet.Attributes;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace SimpleCDN.Benchmarks
 {
+	[MemoryDiagnoser(false)]
+	[SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Needed for BenchmarkDotNet")]
 	public class Benchmarks
 	{
+		public IEnumerable<char[]> Paths =>
+		[
+			"/".ToCharArray(),
+			"/../".ToCharArray(),
+			"/data/../".ToCharArray(),
+			"/test.txt".ToCharArray(),
+			"/data/../test.txt".ToCharArray(),
+			"/data/test.json".ToCharArray(),
+			"/data/../data/test.json".ToCharArray(),
+			"/data/./../data/test.json".ToCharArray(),
+			"/data/data/../../data/test.json".ToCharArray(),
+			"/data/data/../../data/../data/test.json".ToCharArray(),
+			"/data/data/../../data/../data/../data/test.json".ToCharArray(),
+			"/data/data/.././data/../../../data/../data/test.json".ToCharArray(),
+		];
+
+		[ParamsSource(nameof(Paths))]
+		public char[] Path { get; set; } = [];
+
 		const int NormalizationBenchmarkIterationsPerInvoke = 100;
+
 		[Benchmark(OperationsPerInvoke = NormalizationBenchmarkIterationsPerInvoke)]
 		public void NormalizationBenchmark()
 		{
-			var path = "/a/b/c/../d/e/f/./d/e/a/../../q/r/s/t/u/./v/w/x/y/z".ToCharArray();
-			var span = path.AsSpan();
+			var span = Path.AsSpan();
 			for (var i = 0; i < NormalizationBenchmarkIterationsPerInvoke; i++)
 			{
 				Helpers.Extensions.Normalize(ref span);

--- a/SimpleCDN.Benchmarks/Benchmarks.cs
+++ b/SimpleCDN.Benchmarks/Benchmarks.cs
@@ -1,0 +1,24 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SimpleCDN.Benchmarks
+{
+	public class Benchmarks
+	{
+		const int NormalizationBenchmarkIterationsPerInvoke = 100;
+		[Benchmark(OperationsPerInvoke = NormalizationBenchmarkIterationsPerInvoke)]
+		public void NormalizationBenchmark()
+		{
+			var path = "/a/b/c/../d/e/f/./d/e/a/../../q/r/s/t/u/./v/w/x/y/z".ToCharArray();
+			var span = path.AsSpan();
+			for (var i = 0; i < NormalizationBenchmarkIterationsPerInvoke; i++)
+			{
+				Helpers.Extensions.Normalize(ref span);
+			}
+		}
+	}
+}

--- a/SimpleCDN.Benchmarks/Benchmarks.cs
+++ b/SimpleCDN.Benchmarks/Benchmarks.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 namespace SimpleCDN.Benchmarks
 {
 	[MemoryDiagnoser(false)]
-	[SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Needed for BenchmarkDotNet")]
 	public class Benchmarks
 	{
 		public IEnumerable<char[]> Paths =>

--- a/SimpleCDN.Benchmarks/Program.cs
+++ b/SimpleCDN.Benchmarks/Program.cs
@@ -1,0 +1,4 @@
+﻿using BenchmarkDotNet.Running;
+using SimpleCDN.Benchmarks;
+
+BenchmarkRunner.Run<Benchmarks>();

--- a/SimpleCDN.Benchmarks/SimpleCDN.Benchmarks.csproj
+++ b/SimpleCDN.Benchmarks/SimpleCDN.Benchmarks.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SimpleCDN\SimpleCDN.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SimpleCDN.Tests/NormalizeTests.cs
+++ b/SimpleCDN.Tests/NormalizeTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SimpleCDN.Tests
+{
+	[TestFixture]
+	public class NormalizeTests
+	{
+		[TestCase("/aaaa/../bbbb", "/bbbb")]
+		[TestCase("/aaaa/./bbbb", "/aaaa/bbbb")]
+		[TestCase("/aaaa/./bbbb/./cccc", "/aaaa/bbbb/cccc")]
+		[TestCase("/../aaaa/./bbbb/./cccc", "/aaaa/bbbb/cccc")]
+		[TestCase("/aaaa/./bbbb/./cccc/..", "/aaaa/bbbb")]
+		[TestCase("/aaaa/./bbbb/./cccc/../../dddd", "/aaaa/dddd")]
+		public void Test_Normalize_Normalizes(string path, string expected)
+		{
+			var pathChars = path.ToCharArray();
+			var span = pathChars.AsSpan();
+
+			Helpers.Extensions.Normalize(ref span);
+
+			Assert.That(span.ToString(), Is.EqualTo(expected));
+		}
+	}
+}

--- a/SimpleCDN.sln
+++ b/SimpleCDN.sln
@@ -10,6 +10,8 @@ Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-co
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleCDN.Tests.Integration", "SimpleCDN.Tests.Integration\SimpleCDN.Tests.Integration.csproj", "{F79E71E8-89D8-46F7-802C-CFDF3A77447D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleCDN.Benchmarks", "SimpleCDN.Benchmarks\SimpleCDN.Benchmarks.csproj", "{73BC9966-46FF-40D8-89F4-C990B15370A2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,9 +31,12 @@ Global
 		{81DDED9D-158B-E303-5F62-77A2896D2A5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{81DDED9D-158B-E303-5F62-77A2896D2A5A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F79E71E8-89D8-46F7-802C-CFDF3A77447D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F79E71E8-89D8-46F7-802C-CFDF3A77447D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F79E71E8-89D8-46F7-802C-CFDF3A77447D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F79E71E8-89D8-46F7-802C-CFDF3A77447D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{73BC9966-46FF-40D8-89F4-C990B15370A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{73BC9966-46FF-40D8-89F4-C990B15370A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{73BC9966-46FF-40D8-89F4-C990B15370A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{73BC9966-46FF-40D8-89F4-C990B15370A2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SimpleCDN/Helpers/EnumerableExtensions.cs
+++ b/SimpleCDN/Helpers/EnumerableExtensions.cs
@@ -1,0 +1,23 @@
+﻿namespace SimpleCDN.Helpers
+{
+	public static class EnumerableExtensions
+	{
+		public static (T left, IEnumerable<T> right) RemoveFirst<T>(this IEnumerable<T> source)
+		{
+			var enumerator = source.GetEnumerator();
+
+			if (!enumerator.MoveNext())
+				ArgumentOutOfRangeException.ThrowIfLessThan(0, 1, nameof(source));
+
+			return (enumerator.Current, RestEnumerator(enumerator));
+
+			static IEnumerable<T> RestEnumerator(IEnumerator<T> enumerator)
+			{
+				while (enumerator.MoveNext())
+				{
+					yield return enumerator.Current;
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This pull request introduces a benchmarking suite for the SimpleCDN project and refactors some existing code. The key changes include the addition of benchmark tests, updates to the solution file, and refactoring of path normalization logic.

### Benchmarking Suite:
* [`SimpleCDN.Benchmarks/Benchmarks.cs`](diffhunk://#diff-8ed5bf171440d45497e6de3db5545ffe856aeafe84dc7577e587f7d7be20faf4R1-R45): Added a new class `Benchmarks` with memory diagnostics and a `NormalizationBenchmark` method to measure the performance of path normalization.
* [`SimpleCDN.Benchmarks/Program.cs`](diffhunk://#diff-a166bc6eed753be0baca43a6bc532b80144d1b1311e41758ae8854118b7757b4R1-R4): Added a program entry point to run the benchmarks using BenchmarkDotNet.
* [`SimpleCDN.Benchmarks/SimpleCDN.Benchmarks.csproj`](diffhunk://#diff-5da5ee0fddbdb6537217f747661f2019340c61fe014f5505531f33cddfdb869cR1-R18): Created a new project file for the benchmarking suite, including necessary dependencies and project references.

### Solution File Update:
* [`SimpleCDN.sln`](diffhunk://#diff-a24b6b35e41bbf9f84f04b8adbe41819c3fb30eb52dac2083a9aee4ccb791d05R13-R14): Updated the solution file to include the new `SimpleCDN.Benchmarks` project and its build configurations. [[1]](diffhunk://#diff-a24b6b35e41bbf9f84f04b8adbe41819c3fb30eb52dac2083a9aee4ccb791d05R13-R14) [[2]](diffhunk://#diff-a24b6b35e41bbf9f84f04b8adbe41819c3fb30eb52dac2083a9aee4ccb791d05L32-R39)

### Code Refactoring:
* [`SimpleCDN/Helpers/Extensions.cs`](diffhunk://#diff-11ab6c3b0ce1716c11fee9d7c11bfcd42dc4e43372d5d4704805cb05ee9a3282L37-R84): Refactored the `Normalize` method to improve readability and efficiency by using a stack to manage path segments. [[1]](diffhunk://#diff-11ab6c3b0ce1716c11fee9d7c11bfcd42dc4e43372d5d4704805cb05ee9a3282L37-R84) [[2]](diffhunk://#diff-11ab6c3b0ce1716c11fee9d7c11bfcd42dc4e43372d5d4704805cb05ee9a3282R116-R121)
* [`SimpleCDN/Helpers/EnumerableExtensions.cs`](diffhunk://#diff-a73aeea60fd82380a4385738c2ad45182b1008247302d548222e73104990077eR1-R23): Moved the `RemoveFirst` extension method from `Extensions.cs` to a new file `EnumerableExtensions.cs` for better organization.

### New Tests:
* [`SimpleCDN.Tests/NormalizeTests.cs`](diffhunk://#diff-d0549d70ef36a190270869c9510b67a37a612fa90e02add4232f515ec04e4ae2R1-R28): Added unit tests for the `Normalize` method to ensure correct functionality.