### PR TITLE
Add redis support

### DIFF
--- a/SimpleCDN.Tests.Unit/CacheManagerTests.cs
+++ b/SimpleCDN.Tests.Unit/CacheManagerTests.cs
@@ -1,4 +1,5 @@
 ﻿using SimpleCDN.Cache;
+using SimpleCDN.Configuration;
 using SimpleCDN.Helpers;
 using SimpleCDN.Services;
 using SimpleCDN.Tests.Mocks;
@@ -14,14 +15,23 @@ namespace SimpleCDN.Tests.Unit
 		const string TEST_DATA_3 = TEST_DATA_2 + TEST_DATA_2 + TEST_DATA_2 + TEST_DATA_2 + TEST_DATA_2 + TEST_DATA_2;
 		const string TEST_PATH = "/hello.txt";
 
+		private static (CacheManager manager, DistributedCacheMock implementation) CreateCache(Action<CacheConfiguration>? configure = null)
+		{
+			var cacheImplementation = new DistributedCacheMock();
+
+			var options = new CacheConfiguration();
+			configure?.Invoke(options);
+
+			var cache = new CacheManager(cacheImplementation, new OptionsMock<CacheConfiguration>(options));
+			return (cache, cacheImplementation);
+		}
+
 		[TestCase(TEST_DATA_1)]
 		[TestCase(TEST_DATA_2)]
 		[TestCase(TEST_DATA_3)]
 		public void Test_Add_Exists(string data)
 		{
-			var cacheImplementation = new DistributedCacheMock();
-
-			var cache = new CacheManager(cacheImplementation);
+			(CacheManager cache, DistributedCacheMock cacheImplementation) = CreateCache();
 
 			var file = new CachedFile
 			{
@@ -47,8 +57,7 @@ namespace SimpleCDN.Tests.Unit
 		[TestCase(TEST_DATA_3)]
 		public void Test_Add_Remove_DoesNotExist(string data)
 		{
-			var cacheImplementation = new DistributedCacheMock();
-			var cache = new CacheManager(cacheImplementation);
+			(CacheManager cache, DistributedCacheMock cacheImplementation) = CreateCache();
 
 			var file = new CachedFile
 			{

--- a/SimpleCDN.Tests.Unit/RemoveFirstTests.cs
+++ b/SimpleCDN.Tests.Unit/RemoveFirstTests.cs
@@ -1,0 +1,55 @@
+﻿using SimpleCDN.Helpers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SimpleCDN.Tests.Unit
+{
+	public class RemoveFirstTests
+	{
+		[Test]
+		public void RemoveFirst_Empty()
+		{
+			IEnumerable<int> source = [];
+			Assert.That(source.RemoveFirst, Throws.InstanceOf<ArgumentOutOfRangeException>());
+		}
+
+		[Test]
+		public void RemoveFirst_OneElement()
+		{
+			IEnumerable<int> source = [1];
+			(int left, IEnumerable<int> right) = source.RemoveFirst();
+			Assert.Multiple(() =>
+			{
+				Assert.That(left, Is.EqualTo(1));
+				Assert.That(right, Is.Empty);
+			});
+		}
+
+		[Test]
+		public void RemoveFirst_TwoElements()
+		{
+			IEnumerable<int> source = [1, 2];
+			(int left, IEnumerable<int> right) = source.RemoveFirst();
+			Assert.Multiple(() =>
+			{
+				Assert.That(left, Is.EqualTo(1));
+				Assert.That(right, Is.EqualTo([2]));
+			});
+		}
+
+		[Test]
+		public void RemoveFirst_ThreeElements()
+		{
+			IEnumerable<int> source = [1, 2, 3];
+			(int left, IEnumerable<int> right) = source.RemoveFirst();
+			Assert.Multiple(() =>
+			{
+				Assert.That(left, Is.EqualTo(1));
+				Assert.That(right, Is.EqualTo([2, 3]));
+			});
+		}
+	}
+}

--- a/SimpleCDN.Tests.Unit/SizeLimitedCacheTests.cs
+++ b/SimpleCDN.Tests.Unit/SizeLimitedCacheTests.cs
@@ -12,15 +12,18 @@ namespace SimpleCDN.Tests.Unit
 {
 	public class SizeLimitedCacheTests
 	{
-		private static SizeLimitedCache CreateCache(Action<InMemoryCacheConfiguration>? configure = null)
+		private static SizeLimitedCache CreateCache(Action<InMemoryCacheConfiguration>? configure = null, Action<CacheConfiguration>? configureCache = null)
 		{
 			var options = new InMemoryCacheConfiguration();
+			var cacheOptions = new CacheConfiguration();
 
 			configure?.Invoke(options);
+			configureCache?.Invoke(cacheOptions);
 
 			var optionsMock = new OptionsMock<InMemoryCacheConfiguration>(options);
+			var cacheOptionsMock = new OptionsMock<CacheConfiguration>(cacheOptions);
 
-			return new SizeLimitedCache(optionsMock, new MockLogger<SizeLimitedCache>());
+			return new SizeLimitedCache(optionsMock, cacheOptionsMock, new MockLogger<SizeLimitedCache>());
 		}
 
 		[Test]

--- a/SimpleCDN.Tests.Unit/SizeLimitedCacheTests.cs
+++ b/SimpleCDN.Tests.Unit/SizeLimitedCacheTests.cs
@@ -1,0 +1,89 @@
+﻿using Microsoft.Extensions.Caching.Distributed;
+using SimpleCDN.Cache;
+using SimpleCDN.Configuration;
+using SimpleCDN.Tests.Mocks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SimpleCDN.Tests.Unit
+{
+	public class SizeLimitedCacheTests
+	{
+		private static SizeLimitedCache CreateCache(Action<InMemoryCacheConfiguration>? configure = null)
+		{
+			var options = new InMemoryCacheConfiguration();
+
+			configure?.Invoke(options);
+
+			var optionsMock = new OptionsMock<InMemoryCacheConfiguration>(options);
+
+			return new SizeLimitedCache(optionsMock, new MockLogger<SizeLimitedCache>());
+		}
+
+		[Test]
+		public void Test_UnaddedFile_Misses()
+		{
+			SizeLimitedCache cache = CreateCache();
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(cache.Count, Is.Zero);
+				Assert.That(cache.Size, Is.Zero);
+				Assert.That(cache.Keys, Is.Empty);
+			});
+			Assert.That(cache.Get("/hello.txt"), Is.Null);
+		}
+
+		[Test]
+		public void Test_AddedFile_Hits()
+		{
+			SizeLimitedCache cache = CreateCache();
+			const string TEST_DATA = "Hello, World!";
+			const string TEST_PATH = "/hello.txt";
+			cache.Set(TEST_PATH, Encoding.UTF8.GetBytes(TEST_DATA), new DistributedCacheEntryOptions());
+			Assert.Multiple(() =>
+			{
+				Assert.That(cache.Count, Is.EqualTo(1));
+				Assert.That(cache.Size, Is.EqualTo(TEST_DATA.Length));
+				Assert.That(cache.Keys, Is.EquivalentTo([TEST_PATH]));
+			});
+			Assert.That(cache.Get(TEST_PATH), Is.EqualTo(Encoding.UTF8.GetBytes(TEST_DATA)));
+		}
+
+		[TestCase(0, true)]
+		[TestCase(1, true)]
+		[TestCase(1000, true)]
+		[TestCase(1001, false)]
+		[TestCase(10000, false)]
+		public void Test_AddedFile_TooLarge(int size, bool shouldPass)
+		{
+			SizeLimitedCache cache = CreateCache(options => options.MaxSize = 1);
+			const string TEST_PATH = "/hello.txt";
+			string testData = new string('*', size);
+			cache.Set(TEST_PATH, Encoding.UTF8.GetBytes(testData), new DistributedCacheEntryOptions());
+
+			if (shouldPass)
+			{
+				Assert.Multiple(() =>
+				{
+					Assert.That(cache.Count, Is.EqualTo(1));
+					Assert.That(cache.Size, Is.EqualTo(testData.Length));
+					Assert.That(cache.Keys, Is.EquivalentTo([TEST_PATH]));
+				});
+				Assert.That(cache.Get(TEST_PATH), Is.Not.Null);
+			} else
+			{
+				Assert.Multiple(() =>
+				{
+					Assert.That(cache.Count, Is.Zero);
+					Assert.That(cache.Size, Is.Zero);
+					Assert.That(cache.Keys, Is.Empty);
+				});
+				Assert.That(cache.Get(TEST_PATH), Is.Null);
+			}
+		}
+	}
+}

--- a/SimpleCDN/Cache/DisabledCache.cs
+++ b/SimpleCDN/Cache/DisabledCache.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Extensions.Caching.Distributed;
+
+namespace SimpleCDN.Cache
+{
+	/// <summary>
+	/// A cache that does nothing. Used when caching is disabled.
+	/// </summary>
+	public class DisabledCache : IDistributedCache
+	{
+		public byte[]? Get(string key) => null;
+		public Task<byte[]?> GetAsync(string key, CancellationToken token = default) => FromResultOrCancelled(Get(key), token);
+		public void Refresh(string key) { }
+		public Task RefreshAsync(string key, CancellationToken token = default) => MayBeCancelled(token);
+		public void Remove(string key) { }
+		public Task RemoveAsync(string key, CancellationToken token = default) => MayBeCancelled(token);
+		public void Set(string key, byte[] value, DistributedCacheEntryOptions options) { }
+		public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default) => MayBeCancelled(token);
+
+
+		private static Task<T> FromResultOrCancelled<T>(T result, CancellationToken token)
+		{
+			return token.IsCancellationRequested ? Task.FromCanceled<T>(token) : Task.FromResult(result);
+		}
+
+		private static Task MayBeCancelled(CancellationToken token)
+		{
+			return token.IsCancellationRequested ? Task.FromCanceled(token) : Task.CompletedTask;
+		}
+	}
+}

--- a/SimpleCDN/Configuration/CDNConfiguration.cs
+++ b/SimpleCDN/Configuration/CDNConfiguration.cs
@@ -5,13 +5,13 @@
 		/// <summary>
 		/// The data root path
 		/// </summary>
-		public required string DataRoot { get; set; }
+		public string DataRoot { get; set; } = "";
 
 		/// <summary>
 		/// The footer to be added to the bottom of generated index files. Default is a link to the SimpleCDN GitHub repository
 		/// and the text "Powered by SimpleCDN". Supports HTML.
 		/// </summary>
-		public string Footer { get; set; } = $"""<a href="https://github.com/jonathanbout/simplecdn">Powered by SimpleCDN</a>""";
+		public string Footer { get; set; } = """<a href="https://github.com/jonathanbout/simplecdn">Powered by SimpleCDN</a>""";
 
 		/// <summary>
 		/// The title of the generated index files. Default is "SimpleCDN". Supports HTML entities.
@@ -21,7 +21,7 @@
 		/// <summary>
 		/// The maximum size of a cached item in kB. Default is 8000 (8 MB)
 		/// </summary>
-		public int MaxCachedItemSize { get; set; } = 500_000;
+		public int MaxCachedItemSize { get; set; } = 8_000;
 
 		private bool _showDotFiles;
 

--- a/SimpleCDN/Configuration/CacheConfiguration.cs
+++ b/SimpleCDN/Configuration/CacheConfiguration.cs
@@ -6,5 +6,49 @@
 		/// The maximum size of the in-memory cache in kB. Default is 500,000 (500 MB)
 		/// </summary>
 		public uint MaxSize { get; set; } = 500_000; // 500 MB
+		/// <summary>
+		/// The maximum age of an item in the cache in Minutes. Default is 1 day.
+		/// Set to 0 to disable automatic expiration.
+		/// </summary>
+		public uint MaxAge { get; set; } = 60 * 24; // 1 day
+		/// <summary>
+		/// The interval at which the cache is purged of expired items in Minutes. Default is 1 hour.
+		/// Set to 0 to disable automatic purging.
+		/// </summary>
+		public uint PurgeInterval { get; set; } = 60; // 1 hour
+	}
+
+	public class RedisCacheConfiguration
+	{
+		public string ConnectionString { get; set; } = "localhost";
+		public string InstanceName { get; set; } = "SimpleCDN";
+	}
+
+	public class CacheConfiguration
+	{
+		/// <summary>
+		/// The configuration for the in-memory cache
+		/// </summary>
+		public InMemoryCacheConfiguration? InMemory { get; set; }
+		public RedisCacheConfiguration? Redis { get; set; }
+		private int _type = -1;
+		/// <summary>
+		/// The type of cache to use. Defaults to Redis if configured, otherwise InMemory.
+		/// Set to <see cref="CacheType.Disabled"/> to disable caching. This is useful for testing, but discouraged in production.
+		/// <br/>
+		/// Changing this value requires a restart of the application.
+		/// </summary>
+		public CacheType Type
+		{
+			get => Enum.IsDefined((CacheType)_type) ? (CacheType)_type : Redis is not null ? CacheType.Redis : CacheType.InMemory;
+			set => _type = (int)value;
+		}
+
+		public enum CacheType
+		{
+			Disabled,
+			InMemory,
+			Redis
+		}
 	}
 }

--- a/SimpleCDN/Configuration/CacheConfiguration.cs
+++ b/SimpleCDN/Configuration/CacheConfiguration.cs
@@ -1,29 +1,5 @@
 ﻿namespace SimpleCDN.Configuration
 {
-	public class InMemoryCacheConfiguration
-	{
-		/// <summary>
-		/// The maximum size of the in-memory cache in kB. Default is 500,000 (500 MB)
-		/// </summary>
-		public uint MaxSize { get; set; } = 500_000; // 500 MB
-		/// <summary>
-		/// The maximum age of an item in the cache in Minutes. Default is 1 day.
-		/// Set to 0 to disable automatic expiration.
-		/// </summary>
-		public uint MaxAge { get; set; } = 60 * 24; // 1 day
-		/// <summary>
-		/// The interval at which the cache is purged of expired items in Minutes. Default is 1 hour.
-		/// Set to 0 to disable automatic purging.
-		/// </summary>
-		public uint PurgeInterval { get; set; } = 60; // 1 hour
-	}
-
-	public class RedisCacheConfiguration
-	{
-		public string ConnectionString { get; set; } = "localhost";
-		public string InstanceName { get; set; } = "SimpleCDN";
-	}
-
 	public class CacheConfiguration
 	{
 		/// <summary>
@@ -43,6 +19,12 @@
 			get => Enum.IsDefined((CacheType)_type) ? (CacheType)_type : Redis is not null ? CacheType.Redis : CacheType.InMemory;
 			set => _type = (int)value;
 		}
+
+		/// <summary>
+		/// The maximum age of an item in the cache in Minutes. Default is 1 day.
+		/// Set to 0 to disable automatic expiration.
+		/// </summary>
+		public uint MaxAge { get; set; } = 60 * 24; // 1 day
 
 		public enum CacheType
 		{

--- a/SimpleCDN/Configuration/InMemoryCacheConfiguration.cs
+++ b/SimpleCDN/Configuration/InMemoryCacheConfiguration.cs
@@ -1,0 +1,16 @@
+﻿namespace SimpleCDN.Configuration
+{
+	public class InMemoryCacheConfiguration
+	{
+		/// <summary>
+		/// The maximum size of the in-memory cache in kB. Default is 500,000 (500 MB)
+		/// </summary>
+		public uint MaxSize { get; set; } = 500_000; // 500 MB
+
+		/// <summary>
+		/// The interval at which the cache is purged of expired items in Minutes. Default is 1 hour.
+		/// Set to 0 to disable automatic purging.
+		/// </summary>
+		public uint PurgeInterval { get; set; } = 60; // 1 hour
+	}
+}

--- a/SimpleCDN/Configuration/RedisCacheConfiguration.cs
+++ b/SimpleCDN/Configuration/RedisCacheConfiguration.cs
@@ -1,0 +1,8 @@
+﻿namespace SimpleCDN.Configuration
+{
+	public class RedisCacheConfiguration
+	{
+		public string ConnectionString { get; set; } = "localhost";
+		public string InstanceName { get; set; } = "SimpleCDN";
+	}
+}

--- a/SimpleCDN/Helpers/EnumerableExtensions.cs
+++ b/SimpleCDN/Helpers/EnumerableExtensions.cs
@@ -1,17 +1,20 @@
-﻿
-
-using Microsoft.Net.Http.Headers;
+﻿using Microsoft.Net.Http.Headers;
 
 namespace SimpleCDN.Helpers
 {
 	public static class EnumerableExtensions
 	{
+		/// <summary>
+		/// Removes the first element from the enumerable and returns it along with the rest of the enumerable.
+		/// </summary>
+		/// <returns>The first element of <paramref name="source"/></returns>
+		/// <exception cref="ArgumentOutOfRangeException"></exception>
 		public static (T left, IEnumerable<T> right) RemoveFirst<T>(this IEnumerable<T> source)
 		{
-			var enumerator = source.GetEnumerator();
+			using IEnumerator<T> enumerator = source.GetEnumerator();
 
 			if (!enumerator.MoveNext())
-				ArgumentOutOfRangeException.ThrowIfLessThan(0, 1, nameof(source));
+				throw new ArgumentOutOfRangeException(nameof(source));
 
 			return (enumerator.Current, RestEnumerator(enumerator));
 
@@ -24,9 +27,12 @@ namespace SimpleCDN.Helpers
 			}
 		}
 
+		/// <summary>
+		/// Compares the media type of the <see cref="MediaTypeHeaderValue"/> to the provided media type string.
+		/// </summary>
 		public static bool ContainsMediaType(this IList<MediaTypeHeaderValue> list, string mediaType)
 		{
-			foreach (var item in list)
+			foreach (MediaTypeHeaderValue item in list)
 			{
 				if (MTHVComparer.Instance.Equals(item, new MediaTypeHeaderValue(mediaType)))
 				{

--- a/SimpleCDN/Helpers/Extensions.cs
+++ b/SimpleCDN/Helpers/Extensions.cs
@@ -177,5 +177,13 @@ namespace SimpleCDN.Helpers
 			// we've reached the end of the input, but we still have prefixes to check
 			return false;
 		}
+
+		public static void RemoveWhere<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, Func<KeyValuePair<TKey, TValue>, bool> predicate)
+		{
+			foreach ((TKey key, _) in dictionary.Where(predicate).ToList())
+			{
+				dictionary.Remove(key);
+			}
+		}
 	}
 }

--- a/SimpleCDN/Services/CacheManager.cs
+++ b/SimpleCDN/Services/CacheManager.cs
@@ -65,6 +65,7 @@ namespace SimpleCDN.Services
 				return new DebugView(
 					slc.GetType().Name,
 					slc.Size,
+					slc.MaxSize,
 					slc.Count,
 					[.. slc.Keys]
 				);
@@ -76,5 +77,8 @@ namespace SimpleCDN.Services
 
 	internal record BasicDebugView(string Implementation);
 
-	internal record DebugView(string Implementation, long Size, int Count, string[] Elements) : BasicDebugView(Implementation);
+	internal record DebugView(string Implementation, long Size, long MaxSize, int Count, string[] Elements) : BasicDebugView(Implementation)
+	{
+		public decimal FillPercentage => (decimal)Size / MaxSize * 100;
+	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,10 @@
 services:
+  redis:
+    # this service is only needed if you are using the Redis cache with Cache__Type=Redis
+    image: redis:alpine
+    ports:
+    - "6379:6379"
+
   simplecdn:
     image: ${DOCKER_REGISTRY-}simplecdn:local-dev
     build:
@@ -11,10 +17,5 @@ services:
     environment:
     - CDN_DATA_ROOT=/data
     - ASPNETCORE_ENVIRONMENT=Development
-    healthcheck:
-        test: ["CMD", "/bin/health-check.sh"]
-        interval: 30s
-        timeout: 5s
-        start_interval: 2s
-        start_period: 2s
-        retries: 5
+    - Cache__Redis__ConnectionString=redis:6379 # Only needed if Cache__Type=Redis
+    - Cache__Type=Redis # Redis, InMemory, or Disabled


### PR DESCRIPTION
- More unit tests for vital parts of the code
- DisabledCache to make disabling the cache possible
- In-Memory cache automatically removes stale data
- Redis support for running multiple instances. I haven't ran any performance tests, but it doesn't seem to bring a big performance loss compared to raw in-memory

Putting this in a separate docker image is not needed IMO, as the size of the image hasn't increased by a lot.