### PR TITLE
Properly block robots

### DIFF
--- a/SimpleCDN/Configuration/CDNConfiguration.cs
+++ b/SimpleCDN/Configuration/CDNConfiguration.cs
@@ -38,9 +38,9 @@
 		}
 
 		/// <summary>
-		/// Whether to block web crawlers from indexing the CDN files. Default is false.
+		/// Whether to block web crawlers and other bots from indexing the CDN files. Default is true.
 		/// </summary>
-		public bool BlockCrawlers { get; set; }
+		public bool BlockRobots { get; set; } = true;
 
 		/// <summary>
 		/// Whether to allow access to files and directories starting with a dot (e.g. .ssl). Default is false.

--- a/SimpleCDN/Program.cs
+++ b/SimpleCDN/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using SimpleCDN.Cache;
 using SimpleCDN.Configuration;
 using SimpleCDN.Endpoints;
@@ -81,8 +82,12 @@ namespace SimpleCDN
 
 			app.Use(async (ctx, next) =>
 			{
+				CDNConfiguration configuration = ctx.RequestServices.GetRequiredService<IOptionsSnapshot<CDNConfiguration>>().Value;
 				ctx.Response.Headers.Server = "SimpleCDN";
-				ctx.Response.Headers["X-Robots-Tag"] = "noindex, nofollow";
+				if (configuration.BlockRobots)
+				{
+					ctx.Response.Headers["X-Robots-Tag"] = "noindex, nofollow";
+				}
 				await next();
 			});
 

--- a/SimpleCDN/Services/IndexGenerator.cs
+++ b/SimpleCDN/Services/IndexGenerator.cs
@@ -20,7 +20,7 @@ namespace SimpleCDN.Services
 
 			var index = new StringBuilder();
 
-			string robotsMeta = _options.CurrentValue.AllowDotFileAccess ? "" : "<meta name=\"robots\" content=\"noindex, nofollow\">";
+			string robotsMeta = _options.CurrentValue.BlockRobots ? "<meta name=\"robots\" content=\"noindex, nofollow\">" : "";
 
 			index.AppendFormat(
 				"""


### PR DESCRIPTION
- Updated `X-Robots-Tag` header to follow the configured setting
- Renamed `BlockCrawlers` to `BlockRobots` and changed default from `false` to `true`