### PR TITLE
(More) stable Redis caching

### DIFF
--- a/SimpleCDN.Tests.Unit/CacheManagerTests.cs
+++ b/SimpleCDN.Tests.Unit/CacheManagerTests.cs
@@ -22,7 +22,7 @@ namespace SimpleCDN.Tests.Unit
 			var options = new CacheConfiguration();
 			configure?.Invoke(options);
 
-			var cache = new CacheManager(cacheImplementation, new OptionsMock<CacheConfiguration>(options));
+			var cache = new CacheManager(cacheImplementation, new OptionsMock<CacheConfiguration>(options), new MockLogger<CacheManager>());
 			return (cache, cacheImplementation);
 		}
 

--- a/SimpleCDN/Globals.cs
+++ b/SimpleCDN/Globals.cs
@@ -32,7 +32,11 @@ namespace SimpleCDN
 
 	[JsonSourceGenerationOptions]
 	[JsonSerializable(typeof(BasicDebugView))]
+#if DEBUG
 	[JsonSerializable(typeof(DebugView))]
+	[JsonSerializable(typeof(DetailedDebugView))]
+#endif
 	[JsonSerializable(typeof(SizeLimitedCacheDebugView))]
+	[JsonSerializable(typeof(CustomRedisCacheServiceDebugView))]
 	internal partial class SourceGenerationContext : JsonSerializerContext;
 }

--- a/SimpleCDN/Helpers/ObjectAccessBalancer.cs
+++ b/SimpleCDN/Helpers/ObjectAccessBalancer.cs
@@ -1,0 +1,128 @@
+﻿
+namespace SimpleCDN.Helpers
+{
+	/// <summary>
+	/// Balances access to a collection of instances of <typeparamref name="T"/>.
+	/// </summary>
+	/// <param name="instanceFactory">How an instance should be created</param>
+	public sealed class ObjectAccessBalancer<T>(Func<T> instanceFactory) : IDisposable, IAsyncDisposable
+	{
+		private readonly List<T> _instances = [instanceFactory()];
+		private T? _lastDeactivatedInstance;
+		private readonly Func<T> _instanceFactory = instanceFactory;
+
+		private int _index;
+		private readonly Lock _lock = new();
+
+		/// <summary>
+		/// The number of instances currently in use in the balancer.
+		/// </summary>
+		public int Count => _instances.Count;
+
+		/// <summary>
+		/// The highest number of instances that have been in use in the balancer at the same time.
+		/// </summary>
+		public int HighestCount { get; private set; } = 1;
+
+		/// <summary>
+		/// Gets the next instance in the balancer.
+		/// </summary>
+		public T Next()
+		{
+			lock (_lock)
+			{
+				if (_index >= _instances.Count)
+				{
+					_index = 0;
+				}
+				return _instances[_index++];
+			}
+		}
+
+		/// <summary>
+		/// Adds a new instance to the balancer.
+		/// </summary>
+		public T AddInstance()
+		{
+			lock (_lock)
+			{
+				if (_lastDeactivatedInstance is not null)
+				{
+					_instances.Add(_lastDeactivatedInstance);
+					_lastDeactivatedInstance = default;
+				} else
+				{
+					_instances.Add(_instanceFactory());
+				}
+
+				if (_instances.Count > HighestCount)
+				{
+					HighestCount = _instances.Count;
+				}
+				return _instances[^1];
+			}
+		}
+
+		/// <summary>
+		/// Removes the last instance added to the balancer, unless there is only one instance.
+		/// The instance is not removed completely until you call this method again.
+		/// Until then, calling <see cref="AddInstance"/> will re-add the removed instance.
+		/// </summary>
+		public void RemoveOneInstance()
+		{
+			lock (_lock)
+			{
+				if (_instances.Count > 0)
+				{
+					if (_lastDeactivatedInstance is IDisposable last)
+					{
+						last.Dispose();
+					}
+					_lastDeactivatedInstance = _instances[^1];
+					_instances.RemoveAt(_instances.Count - 1);
+				}
+			}
+		}
+
+		/// <summary>
+		/// If <typeparamref name="T"/> implements <see cref="IDisposable"/>, disposes all instances.
+		/// <br/>
+		/// You do not need to call this method if your instances do not implement <see cref="IDisposable"/>.
+		/// </summary>
+		public void Dispose()
+		{
+			if (typeof(IDisposable).IsAssignableFrom(typeof(T)))
+			{
+				foreach (T instance in _instances)
+				{
+					(instance as IDisposable)?.Dispose();
+				}
+			}
+		}
+
+		/// <summary>
+		/// If <typeparamref name="T"/> implements <see cref="IAsyncDisposable"/>, disposes all instances asynchronously.
+		/// Also, if <typeparamref name="T"/> implements <see cref="IDisposable"/>, disposes all instances synchronously.
+		/// <br/>
+		/// You do not need to call this method if your instances do not implement <see cref="IAsyncDisposable"/>.
+		/// </summary>
+		public async ValueTask DisposeAsync()
+		{
+			if (typeof(IAsyncDisposable).IsAssignableFrom(typeof(T)))
+			{
+				var tasks = new List<Task>();
+				foreach (T instance in _instances)
+				{
+					if (instance is IAsyncDisposable asyncDisposable)
+					{
+						tasks.Add(asyncDisposable.DisposeAsync().AsTask());
+					}
+				}
+
+				await Task.WhenAll(tasks);
+			}
+
+			Dispose();
+		}
+	}
+}

--- a/SimpleCDN/Services/Caching/CacheManager.cs
+++ b/SimpleCDN/Services/Caching/CacheManager.cs
@@ -3,25 +3,42 @@ using Microsoft.Extensions.Options;
 using SimpleCDN.Cache;
 using SimpleCDN.Configuration;
 using SimpleCDN.Helpers;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace SimpleCDN.Services.Caching
 {
-	public class CacheManager(IDistributedCache cache, IOptionsMonitor<CacheConfiguration> options) : ICacheManager
+	public class CacheManager(IDistributedCache cache, IOptionsMonitor<CacheConfiguration> options, ILogger<CacheManager> logger) : ICacheManager
 	{
 		private readonly IDistributedCache _cache = cache;
 		private readonly IOptionsMonitor<CacheConfiguration> _options = options;
-
+		private readonly ILogger<CacheManager> _logger = logger;
+#if DEBUG
+		private readonly List<ushort> _durations = new(100);
+#endif
 		public bool TryGetValue(string key, [NotNullWhen(true)] out CachedFile? value)
 		{
+			var start = Stopwatch.GetTimestamp();
 			var bytes = _cache.Get(key);
-
+			TimeSpan elapsed = Stopwatch.GetElapsedTime(start);
+#if DEBUG
+			if (_durations.Count == int.MaxValue - 10)
+			{
+				// remove about half of the durations to make room for new ones.
+				// this has the nice side effect of newer values being more important
+				_durations.RemoveAll(_ => Random.Shared.NextDouble() > .5);
+			}
+			_durations.Add((ushort)elapsed.TotalMilliseconds);
+#endif
 			if (bytes is null || bytes.Length == 0)
 			{
+				_logger.LogDebug("Cache MISS for {Key} in {Duration:0} ms", key, elapsed.TotalMilliseconds);
 				value = null;
 				return false;
 			}
+
+			_logger.LogDebug("Cache HIT for {Key} in {Duration:0} ms", key, elapsed.TotalMilliseconds);
 
 			value = CachedFile.FromBytes(bytes);
 
@@ -69,18 +86,55 @@ namespace SimpleCDN.Services.Caching
 
 		public object GetDebugView()
 		{
+#if DEBUG
 			if (_cache is ICacheDebugInfoProvider debugInfoProvider)
 			{
 				return new DebugView(
 					debugInfoProvider.GetType().Name,
+					[.. _durations],
 					debugInfoProvider.GetDebugInfo()
 				);
 			}
 
+			return new DetailedDebugView(_cache.GetType().Name, _durations);
+#else
 			return new BasicDebugView(_cache.GetType().Name);
+#endif
 		}
 	}
 
-	internal record BasicDebugView(string Implementation);
-	internal record DebugView(string Implementation, object Details) : BasicDebugView(Implementation);
+	internal class BasicDebugView(string implementation)
+	{
+		public string Implementation { get; } = implementation;
+	}
+#if DEBUG
+	internal class DetailedDebugView(string implementation, List<ushort> durations) : BasicDebugView(implementation)
+	{
+		public double AverageDuration { get; } = durations.Average(v => (double)v);
+		public double MaxDuration { get; } = durations.Max();
+		public double MinDuration { get; } = durations.Min();
+
+		public double Percentile50 { get; } = Percentile(durations, 0.5);
+		public double Percentile90 { get; } = Percentile(durations, 0.9);
+		public double Percentile95 { get; } = Percentile(durations, 0.95);
+		public double Percentile99 { get; } = Percentile(durations, 0.99);
+
+		public int TotalDurations { get; } = durations.Count;
+
+		/// <summary>
+		/// Calculates the percentile of the given durations.
+		/// </summary>
+		private static double Percentile(List<ushort> durations, double percentile)
+		{
+			var sorted = durations.Order().ToArray();
+			int index = (int)(percentile * sorted.Length);
+			return sorted[index];
+		}
+	}
+
+	internal class DebugView(string implementation, List<ushort> durations, object details) : DetailedDebugView(implementation, durations)
+	{
+		public object Details { get; } = details;
+	}
+#endif
 }

--- a/SimpleCDN/Services/Caching/CustomRedisCacheService.cs
+++ b/SimpleCDN/Services/Caching/CustomRedisCacheService.cs
@@ -3,59 +3,158 @@ using Microsoft.Extensions.Options;
 using SimpleCDN.Configuration;
 using SimpleCDN.Helpers;
 using StackExchange.Redis;
+using System.Diagnostics;
 
 namespace SimpleCDN.Services.Caching
 {
-	public sealed class CustomRedisCacheService : IDistributedCache, IDisposable
+	public sealed class CustomRedisCacheService : IDistributedCache, IAsyncDisposable, ICacheDebugInfoProvider
 	{
 		private readonly IOptionsMonitor<CacheConfiguration> _cacheConfig;
-		private readonly ConnectionMultiplexer _redisConnectionMultiplexer;
+		private readonly ObjectAccessBalancer<ConnectionMultiplexer> _redisConnectionMultiplexers;
+		private readonly ILogger<CustomRedisCacheService> _logger;
 
-		private IDatabase Database => _redisConnectionMultiplexer.GetDatabase();
+		private IDatabase Database => _redisConnectionMultiplexers.Next().GetDatabase();
 		private TimeSpan MaxAge => TimeSpan.FromMinutes(_cacheConfig.CurrentValue.MaxAge);
 
-		public CustomRedisCacheService(IOptionsMonitor<CacheConfiguration> cacheConfig)
+		DateTimeOffset lastTimeout = DateTimeOffset.MaxValue;
+		ushort multiplexerTargetCount = 1;
+
+		public CustomRedisCacheService(IOptionsMonitor<CacheConfiguration> cacheConfig, ILogger<CustomRedisCacheService> logger)
 		{
 			_cacheConfig = cacheConfig;
+			_logger = logger;
 			if (_cacheConfig.CurrentValue is { Type: not CacheConfiguration.CacheType.Redis } or { Redis: null })
 			{
 				throw new InvalidOperationException("Redis cache service is registered, but redis is not configured.");
 			}
 
-			_redisConnectionMultiplexer = ConnectionMultiplexer.Connect(_cacheConfig.CurrentValue.Redis.ConnectionString);
+			// create the instance balancer with the instance factory
+			_redisConnectionMultiplexers = new(
+				() => ConnectionMultiplexer.Connect(
+							_cacheConfig.CurrentValue.Redis!.ConnectionString,
+							options => options.ClientName = cacheConfig.CurrentValue.Redis!.InstanceName));
 		}
 
-		public void Dispose()
-		{
-			_redisConnectionMultiplexer.Dispose();
-		}
+		public ValueTask DisposeAsync() => _redisConnectionMultiplexers.DisposeAsync();
 
 		public byte[]? Get(string key)
 		{
-			RedisValue result = Database.StringGet(key);
-			Database.KeyExpire(key, MaxAge);
-			return result;
+			return Get(key, _redisConnectionMultiplexers.Next());
 		}
 
-		public async Task<byte[]?> GetAsync(string key, CancellationToken token = default)
+		private byte[]? Get(string key, ConnectionMultiplexer multiplexer, int retryCount = 0)
 		{
-			RedisValue result = await Database.StringGetAsync(key);
-			await Database.KeyExpireAsync(key, MaxAge);
-			return result;
+			const int maxRetries = 3;
+			if (retryCount > maxRetries)
+			{
+				return null;
+			}
+
+			try
+			{
+				// keep track of how long the operation takes,
+
+				var start = Stopwatch.GetTimestamp();
+				IDatabase database = multiplexer.GetDatabase();
+
+				RedisValue result = database.StringGet(key);
+				if (result.HasValue)
+				{
+					// reset the expiration time to have a sliding expiration
+					database.KeyExpire(key, MaxAge);
+				}
+				TimeSpan elapsed = Stopwatch.GetElapsedTime(start);
+
+				// if the operation took more than 100ms, create a new multiplexer
+				if (elapsed.TotalMilliseconds > 100)
+				{
+					CreateNewMultiplexer();
+				} else
+				{
+					// no timeout occurred, check if we can reduce the number of multiplexers
+					SyncMultiplexers();
+				}
+
+				return result;
+			} catch (RedisTimeoutException)
+			{
+				// timeout occured, create a new multiplexer and use that to try again, up to 3 times
+				_logger.LogError("Redis timeout exception occurred. Trying to reconnect ({count}/{maxRetries}).", retryCount, maxRetries);
+
+				return Get(key, CreateNewMultiplexer(), retryCount + 1);
+			}
+		}
+
+		/// <summary>
+		/// Create a new multiplexer and set the last timeout to now.
+		/// </summary>
+		private ConnectionMultiplexer CreateNewMultiplexer()
+		{
+			lastTimeout = DateTimeOffset.UtcNow;
+			return _redisConnectionMultiplexers.AddInstance();
+		}
+
+		public Task<byte[]?> GetAsync(string key, CancellationToken token = default)
+		{
+			if (token.IsCancellationRequested)
+				return Task.FromCanceled<byte[]?>(token);
+			return Task.FromResult(Get(key));
 		}
 
 		public void Refresh(string key) { }
 		public Task RefreshAsync(string key, CancellationToken token = default) => Task.CompletedTask;
 		public void Remove(string key) => Database.StringGetDelete(key);
 		public Task RemoveAsync(string key, CancellationToken token = default) => Database.StringGetDeleteAsync(key);
+
 		public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
 		{
-			Database.StringSet(key, value, MaxAge);
+			Database.StringSet(key, value, MaxAge, flags: CommandFlags.FireAndForget);
 		}
 
 		public async Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
 		{
-			await Database.StringSetAsync(key, value, MaxAge);
+			await Database.StringSetAsync(key, value, MaxAge, flags: CommandFlags.FireAndForget);
+		}
+
+		private readonly SemaphoreSlim _syncLock = new(1, 1);
+		/// <summary>
+		/// If no timeouts have occurred in the last 15 seconds, reduce the number of multiplexers by 1.
+		/// </summary>
+		private void SyncMultiplexers()
+		{
+			if (_syncLock.CurrentCount == 0)
+			{
+				return;
+			}
+			_syncLock.Wait();
+			Task.Run(() =>
+			{
+				if (DateTimeOffset.Now - lastTimeout > TimeSpan.FromSeconds(15))
+				{
+					multiplexerTargetCount--;
+					if (multiplexerTargetCount < 1)
+					{
+						multiplexerTargetCount = 1;
+					}
+				}
+				while (_redisConnectionMultiplexers.Count > multiplexerTargetCount)
+				{
+					_redisConnectionMultiplexers.RemoveOneInstance();
+				}
+			})
+				// release the lock when the task is done.
+				// ContinueWith is equivalent to finally in this case.
+				.ContinueWith(_ => _syncLock.Release());
+		}
+
+		/// <summary>
+		/// Get an object containing information about the multiplexers and the last timeout.
+		/// </summary>
+		public object GetDebugInfo()
+		{
+			return new CustomRedisCacheServiceDebugView(_redisConnectionMultiplexers.Count, multiplexerTargetCount, _redisConnectionMultiplexers.HighestCount, lastTimeout == DateTimeOffset.MaxValue ? "never" : lastTimeout.UtcDateTime.ToString());
 		}
 	}
+
+	public record CustomRedisCacheServiceDebugView(int MultiplexerCount, int TargetMultiplexerCount, int HighestMultiplexerCount, string LastTimeout);
 }

--- a/SimpleCDN/appsettings.Development.json
+++ b/SimpleCDN/appsettings.Development.json
@@ -2,7 +2,7 @@
   "Logging": {
     "LogLevel": {
       "Default": "Debug",
-      "Microsoft.AspNetCore": "Debug"
+      "Microsoft.AspNetCore": "Warning"
     }
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,4 +18,4 @@ services:
     - CDN_DATA_ROOT=/data
     - ASPNETCORE_ENVIRONMENT=Development
     - Cache__Redis__ConnectionString=redis:6379 # Only needed if Cache__Type=Redis
-    - Cache__Type=Disabled # Redis, InMemory, or Disabled
+    - Cache__Type=Redis # Redis, InMemory, or Disabled


### PR DESCRIPTION
- Using Redis as a cache backend is now more reliable, as it will grow or shrink the number of connection multiplexers based on actual demand.
- Changed load tests to be indefinite and without delay.
- Better debug view for cache timings

In-memory cache is blazingly fast (on average <1 ms). Redis cache timing is usually somewhere in the range 1-10 ms, but as it depends on the network it can fluctuate a bit more.