### PR TITLE
Make AOT compatible again

### DIFF
--- a/src/core/Endpoints/CDNEndpoints.cs
+++ b/src/core/Endpoints/CDNEndpoints.cs
@@ -36,7 +36,6 @@ namespace SimpleCDN.Endpoints
 				HttpContext ctx,
 				ILogger<CDN> logger,
 				ICompressionManager compressionManager,
-				ICDNContext cdnContext,
 				IOptionsSnapshot<CDNConfiguration> options) =>
 			{
 				ctx.Response.Headers.Server = "SimpleCDN";

--- a/src/core/SimpleCDN.csproj
+++ b/src/core/SimpleCDN.csproj
@@ -21,6 +21,8 @@
 		<PackageIcon>logo.png</PackageIcon>
 		<IncludeSymbols>True</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<IsAotCompatible>true</IsAotCompatible>
+		<EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Due to the conversion into a class library, AOT compatibility was lost. By manually enabling `<IsAotCompatible>` and the `RequestDelegateGenerator`, it is compatible again