### PR TITLE
Improve caching and image size in docker-publish.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,20 +22,10 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners (GitHub.com only)
-    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: 'ubuntu-24.04'
     permissions:
-      # required for all workflows
       security-events: write
-      # required to fetch internal or private CodeQL packs
       packages: read
-      # only required for workflows in private repositories
-      actions: read
-      contents: read
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}-${{ matrix.language }}
       cancel-in-progress: true
@@ -48,27 +38,20 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
-
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+        
+    - run: git checkout HEAD^2
+      if: ${{ github.event_name == 'pull_request' }}
+    
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v4.1.0
       if: ${{ matrix.language == 'csharp' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -87,7 +87,7 @@ jobs:
           outputs: type=image,"name=${{ env.DOCKER_REPO }}",push-by-digest=true,name-canonical=true,push=true
           provenance: false
           sbom: false
-          cache-to: type=gha,scope=image-${{ matrix.dotnet_rid }}
+          cache-to: type=gha,scope=image-${{ matrix.dotnet_rid }},mode=max
           cache-from: type=gha,scope=image-${{ matrix.dotnet_rid }}
           build-args: |
             DOTNET_BUILD_PLATFORM=${{ matrix.dotnet_rid }}

--- a/src/standalone/Dockerfile
+++ b/src/standalone/Dockerfile
@@ -10,48 +10,54 @@ USER $APP_UID
 WORKDIR /app
 ENV CDN__DataRoot=/data
 ENV ASPNETCORE_URLS=http://+:8080
-
 EXPOSE 8080
 
 # This stage is used as the base for the final stage when launching from VS to support debugging in regular mode (Default when not using the Debug configuration)
 FROM base AS aotdebug
 USER root
 # Install GDB to support native debugging
-RUN apt-get update \
+RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
-    gdb
+    gdb \
+    && rm -rf /var/lib/apt/lists/*
 USER app
 
-# This stage is used to build the service project
+# This stage builds the app
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
-# Install clang/zlib1g-dev dependencies for publishing to native
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-    clang zlib1g-dev
 ARG BUILD_CONFIGURATION=Release
 ARG DOTNET_BUILD_PLATFORM=linux-x64
 WORKDIR /code
 
+# Install clang/zlib1g-dev dependencies for publishing to native
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    clang zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# as csproj files don't always change, we can copy them first and potentially cache the restore step
 COPY ["./src/standalone/SimpleCDN.Standalone.csproj", "src/standalone/"]
 COPY ["./src/core/SimpleCDN.csproj", "src/core/"]
 COPY ["./extensions/Redis/SimpleCDN.Extensions.Redis.csproj", "extensions/Redis/"]
 
-RUN dotnet restore "/code/src/standalone/SimpleCDN.Standalone.csproj"
+RUN dotnet restore "/code/src/standalone/SimpleCDN.Standalone.csproj" -r $DOTNET_BUILD_PLATFORM --nologo -v:m
 
+# now copy the rest of the files and build. This part is unlikely to not change,
+# as with most/all releases the code changes
 COPY . .
 WORKDIR "/code/src/standalone"
-RUN dotnet build "./SimpleCDN.Standalone.csproj" -c $BUILD_CONFIGURATION -r $DOTNET_BUILD_PLATFORM -o /app/build
+RUN dotnet build "./SimpleCDN.Standalone.csproj" --no-restore -c $BUILD_CONFIGURATION \
+    -r $DOTNET_BUILD_PLATFORM --nologo -v:m
 
-# This stage is used to publish the service project to be copied to the final stage
+# This stage is used to publish the app.
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
 ARG DOTNET_BUILD_PLATFORM=linux-x64
-RUN dotnet publish "./SimpleCDN.Standalone.csproj" -c $BUILD_CONFIGURATION -r $DOTNET_BUILD_PLATFORM -o /app/publish /p:UseAppHost=true
+RUN dotnet publish "./SimpleCDN.Standalone.csproj" --no-build -c $BUILD_CONFIGURATION \
+    -r $DOTNET_BUILD_PLATFORM -o /app/publish -p:UseAppHost=true --nologo -v:m
 
 # This stage is used in production or when running from VS in regular mode (Default when not using the Debug configuration)
 FROM ${FINAL_BASE_IMAGE:-mcr.microsoft.com/dotnet/runtime-deps:9.0} AS final
 WORKDIR /app
-COPY --from=publish /app/publish .
 
 ENV CDN__DataRoot=/data
 ENV ASPNETCORE_URLS=http://+:8080
@@ -60,8 +66,11 @@ ENV ASPNETCORE_URLS=http://+:8080
 USER root
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    curl
+    curl \
+    && rm -rf /var/lib/apt/lists/*
 USER app
+
+COPY --from=publish /app/publish .
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 CMD curl --silent --fail http://localhost:8080/_cdn/server/health || exit 1
 

--- a/src/standalone/Dockerfile
+++ b/src/standalone/Dockerfile
@@ -48,14 +48,14 @@ WORKDIR "/code/src/standalone"
 RUN dotnet build "./SimpleCDN.Standalone.csproj" --no-restore -c $BUILD_CONFIGURATION \
     -r $DOTNET_BUILD_PLATFORM --nologo -v:m
 
-# This stage is used to publish the app.
+# now use the build output to publish the app into its final form
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
 ARG DOTNET_BUILD_PLATFORM=linux-x64
 RUN dotnet publish "./SimpleCDN.Standalone.csproj" --no-build -c $BUILD_CONFIGURATION \
     -r $DOTNET_BUILD_PLATFORM -o /app/publish -p:UseAppHost=true --nologo -v:m
 
-# This stage is used in production or when running from VS in regular mode (Default when not using the Debug configuration)
+# This stage copies just the published output into a new image
 FROM ${FINAL_BASE_IMAGE:-mcr.microsoft.com/dotnet/runtime-deps:9.0} AS final
 WORKDIR /app
 


### PR DESCRIPTION
- image is about 14MB smaller (68MB > 54MB) meaning faster downloads
- More usage of the cache (4% > 39%), but build still takes 2-2.5 minutes due to cache overhead