### PR TITLE
Update release.yml with more categories

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,13 +2,19 @@ changelog:
   categories:
     - title: Breaking Changes 🛠
       labels:
-        - breaking-change
+        - "breaking change"
     - title: Exciting New Features 🎉
       labels:
         - enhancement
-    - title: Bug Fixes 🐞
+    - title: Bug Fixes 🪲
       labels:
         - bug
+    - title: Performance Improvements 🏎️
+      labels:
+        - performance
+    - title: Dependency Updates
+      labels:
+        - dependencies
     - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
This pull request includes changes to the `.github/release.yml` file to improve the categorization and labeling of changes in the changelog. The most important changes include updating existing labels and adding new categories.

Updates to existing labels:

* Changed the label for breaking changes from `breaking-change` to `"breaking change"`.
* Updated the label for bug fixes from `bug` to `🐞`.

Addition of new categories:

* Added a new category for performance improvements with the label `performance`.
* Added a new category for dependency updates with the label `dependencies`.