### PR TITLE
Unit test for naughty strings

### DIFF
--- a/extensions/Redis/packages.lock.json
+++ b/extensions/Redis/packages.lock.json
@@ -4,9 +4,9 @@
     "net8.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.11, )",
-        "resolved": "8.0.11",
-        "contentHash": "zk5lnZrYJgtuJG8L4v17Ej8rZ3PUcR2iweNV08BaO5LbYHIi2wNaVNcJoLxvqgQdnjLlKnCCfVGLDr6QHeAarQ=="
+        "requested": "[8.0.13, )",
+        "resolved": "8.0.13",
+        "contentHash": "R19ZTaRiQAK+xo9ZwaHbF/1vb1wwR1Wn5+sqp9v8+CDjbdS8R6qftKdw0VSXWKm7VAMi7P+NCU4zxDzhEWcAwQ=="
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
@@ -49,9 +49,9 @@
     "net9.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[9.0.0, )",
-        "resolved": "9.0.0",
-        "contentHash": "zAwp213evC3UkimtVXRb+Dlgc/40QG145nmZDtp2LO9zJJMfrp+i/87BnXN7tRXEA4liyzdFkjqG1HE8/RPb4A=="
+        "requested": "[9.0.2, )",
+        "resolved": "9.0.2",
+        "contentHash": "+KFnCLVPicEq99ko0tq+ycTvNLXHw0tImmTZjPloB/DOFLPT56KLfk5aS7wbgXRPzYhXTTBYLGaABea5mke77w=="
       },
       "Roslynator.Analyzers": {
         "type": "Direct",

--- a/src/core/packages.lock.json
+++ b/src/core/packages.lock.json
@@ -4,9 +4,9 @@
     "net8.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.11, )",
-        "resolved": "8.0.11",
-        "contentHash": "zk5lnZrYJgtuJG8L4v17Ej8rZ3PUcR2iweNV08BaO5LbYHIi2wNaVNcJoLxvqgQdnjLlKnCCfVGLDr6QHeAarQ=="
+        "requested": "[8.0.13, )",
+        "resolved": "8.0.13",
+        "contentHash": "R19ZTaRiQAK+xo9ZwaHbF/1vb1wwR1Wn5+sqp9v8+CDjbdS8R6qftKdw0VSXWKm7VAMi7P+NCU4zxDzhEWcAwQ=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -38,9 +38,9 @@
     "net9.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[9.0.0, )",
-        "resolved": "9.0.0",
-        "contentHash": "zAwp213evC3UkimtVXRb+Dlgc/40QG145nmZDtp2LO9zJJMfrp+i/87BnXN7tRXEA4liyzdFkjqG1HE8/RPb4A=="
+        "requested": "[9.0.2, )",
+        "resolved": "9.0.2",
+        "contentHash": "+KFnCLVPicEq99ko0tq+ycTvNLXHw0tImmTZjPloB/DOFLPT56KLfk5aS7wbgXRPzYhXTTBYLGaABea5mke77w=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/standalone/packages.lock.json
+++ b/src/standalone/packages.lock.json
@@ -20,9 +20,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[9.0.0, )",
-        "resolved": "9.0.0",
-        "contentHash": "zAwp213evC3UkimtVXRb+Dlgc/40QG145nmZDtp2LO9zJJMfrp+i/87BnXN7tRXEA4liyzdFkjqG1HE8/RPb4A=="
+        "requested": "[9.0.2, )",
+        "resolved": "9.0.2",
+        "contentHash": "+KFnCLVPicEq99ko0tq+ycTvNLXHw0tImmTZjPloB/DOFLPT56KLfk5aS7wbgXRPzYhXTTBYLGaABea5mke77w=="
       },
       "Microsoft.VisualStudio.Azure.Containers.Tools.Targets": {
         "type": "Direct",

--- a/tests/unit/SimpleCDN.Tests.Unit.csproj
+++ b/tests/unit/SimpleCDN.Tests.Unit.csproj
@@ -12,6 +12,7 @@
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+		<PackageReference Include="NaughtyStrings" Version="2.4.1" />
 		<PackageReference Include="NUnit" Version="4.3.2" />
 		<PackageReference Include="NUnit.Analyzers" Version="4.6.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />

--- a/tests/unit/SpanExtensionsTests.cs
+++ b/tests/unit/SpanExtensionsTests.cs
@@ -1,4 +1,6 @@
-﻿using SimpleCDN.Helpers;
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using NaughtyStrings;
+using SimpleCDN.Helpers;
 
 namespace SimpleCDN.Tests.Unit
 {
@@ -32,6 +34,33 @@ namespace SimpleCDN.Tests.Unit
 				.ToList();
 
 			Assert.That(resultStrings, Has.None.Contain('/'));
+		}
+
+		[Test]
+		public void SplitPathSegments_NaughthyStrings_StillWorks()
+		{
+			for (int i = 0; i < TheNaughtyStrings.All.Count - 2; i++)
+			{
+				if (TheNaughtyStrings.All[i].Contains('/') || TheNaughtyStrings.All[i + 1].Contains('/')
+				 || TheNaughtyStrings.All[i].Contains('\\') || TheNaughtyStrings.All[i + 1].Contains('\\')
+				 || string.IsNullOrWhiteSpace(TheNaughtyStrings.All[i]) || string.IsNullOrWhiteSpace(TheNaughtyStrings.All[i + 1]))
+				{
+					continue;
+				}
+
+				var path = TheNaughtyStrings.All[i].Trim() + "/" + TheNaughtyStrings.All[i + 1];
+
+				ReadOnlySpan<char> span = path;
+
+				Range[] result = [.. span.SplitToPathSegments()];
+
+				Assert.That(result, Has.Length.EqualTo(2), $"Path: '{path}' of length {path.Length}");
+				Assert.Multiple(() =>
+				{
+					Assert.That(path[result[0]], Is.EqualTo(TheNaughtyStrings.All[i].Trim()));
+					Assert.That(path[result[1]], Is.EqualTo(TheNaughtyStrings.All[i + 1].Trim()));
+				});
+			}
 		}
 	}
 }

--- a/tests/unit/packages.lock.json
+++ b/tests/unit/packages.lock.json
@@ -18,6 +18,12 @@
           "Microsoft.TestPlatform.TestHost": "17.13.0"
         }
       },
+      "NaughtyStrings": {
+        "type": "Direct",
+        "requested": "[2.4.1, )",
+        "resolved": "2.4.1",
+        "contentHash": "6A5+iqfKHkhtoCEqsZKjbj/q9jssEs5K3taCUNBnlTTZd7hR9FUrLY47+cNjfoI3zsrONJaDf8ZBYWIeXe+Y4Q=="
+      },
       "NUnit": {
         "type": "Direct",
         "requested": "[4.3.2, )",
@@ -159,6 +165,12 @@
           "Microsoft.CodeCoverage": "17.13.0",
           "Microsoft.TestPlatform.TestHost": "17.13.0"
         }
+      },
+      "NaughtyStrings": {
+        "type": "Direct",
+        "requested": "[2.4.1, )",
+        "resolved": "2.4.1",
+        "contentHash": "6A5+iqfKHkhtoCEqsZKjbj/q9jssEs5K3taCUNBnlTTZd7hR9FUrLY47+cNjfoI3zsrONJaDf8ZBYWIeXe+Y4Q=="
       },
       "NUnit": {
         "type": "Direct",


### PR DESCRIPTION
This pull request includes several updates to package dependencies across multiple files and introduces new unit tests using the `NaughtyStrings` package.

Dependency updates:

* [`extensions/Redis/packages.lock.json`](diffhunk://#diff-c200e058f1a6a372cbf14cd957dc19ad3cfcad6f57648f4bbaadbc3fdd82f9ecL7-R9): Updated `Microsoft.NET.ILLink.Tasks` from version 8.0.11 to 8.0.13 for `net8.0` and from version 9.0.0 to 9.0.2 for `net9.0`. [[1]](diffhunk://#diff-c200e058f1a6a372cbf14cd957dc19ad3cfcad6f57648f4bbaadbc3fdd82f9ecL7-R9) [[2]](diffhunk://#diff-c200e058f1a6a372cbf14cd957dc19ad3cfcad6f57648f4bbaadbc3fdd82f9ecL52-R54)
* [`src/core/packages.lock.json`](diffhunk://#diff-6c6905e0bde034230d10cb52bc4067442e34f559401e4b7a486a504c01d00209L7-R9): Updated `Microsoft.NET.ILLink.Tasks` from version 8.0.11 to 8.0.13 for `net8.0` and from version 9.0.0 to 9.0.2 for `net9.0`. [[1]](diffhunk://#diff-6c6905e0bde034230d10cb52bc4067442e34f559401e4b7a486a504c01d00209L7-R9) [[2]](diffhunk://#diff-6c6905e0bde034230d10cb52bc4067442e34f559401e4b7a486a504c01d00209L41-R43)
* [`src/standalone/packages.lock.json`](diffhunk://#diff-acf57649b1474d3aeb615dcb8ff5db48613e0ed7aee568319abe5114e2210901L23-R25): Updated `Microsoft.NET.ILLink.Tasks` from version 9.0.0 to 9.0.2.

Unit tests and new package:

* [`tests/unit/SimpleCDN.Tests.Unit.csproj`](diffhunk://#diff-f48b5375d2842bd18f0dc56067d9bc1b6e5243d351a925b4294f954c70015146R15): Added `NaughtyStrings` package version 2.4.1.
* [`tests/unit/SpanExtensionsTests.cs`](diffhunk://#diff-23989398e3c17742868ab08bc96c2be258e54900baa1756a92601bf8b5b5bc15L1-R3): Added a new test method `SplitPathSegments_NaughthyStrings_StillWorks` to validate path segment splitting with naughty strings. [[1]](diffhunk://#diff-23989398e3c17742868ab08bc96c2be258e54900baa1756a92601bf8b5b5bc15L1-R3) [[2]](diffhunk://#diff-23989398e3c17742868ab08bc96c2be258e54900baa1756a92601bf8b5b5bc15R38-R64)
* [`tests/unit/packages.lock.json`](diffhunk://#diff-5f2029e475cfd7ceece32a5a65eeae01d4d51c650a8414b332dcfd7c862cf94dR21-R26): Added `NaughtyStrings` package version 2.4.1. [[1]](diffhunk://#diff-5f2029e475cfd7ceece32a5a65eeae01d4d51c650a8414b332dcfd7c862cf94dR21-R26) [[2]](diffhunk://#diff-5f2029e475cfd7ceece32a5a65eeae01d4d51c650a8414b332dcfd7c862cf94dR169-R174)